### PR TITLE
Replace number inputs for strings

### DIFF
--- a/src/components/AmountInput.svelte
+++ b/src/components/AmountInput.svelte
@@ -6,7 +6,7 @@
   import SelectCollateral from "./SelectCollateral.svelte";
 
   // Props
-  export let inputAmount: number;
+  export let inputAmount: string;
   export let inputError: string;
   export let inputAmountBigNum: BigNumber | undefined;
   export let inputLimit: BigNumber | null;
@@ -26,10 +26,30 @@
   // Function to handle percent button click
   function handlePercentButton(ratio: number) {
     if (inputLimit) {
-      // Calculate the input amount based on the selected ratio
-      inputAmount = +(
-        parseFloat(ethers.utils.formatEther(inputLimit)) * ratio
-      ).toFixed(18);
+      let numerator, denominator;
+      switch (ratio) {
+        case 0.25:
+          numerator = 25;
+          denominator = 100;
+          break;
+        case 0.5:
+          numerator = 50;
+          denominator = 100;
+          break;
+        case 0.75:
+          numerator = 75;
+          denominator = 100;
+          break;
+        case 1:
+          numerator = 1;
+          denominator = 1;
+          break;
+        default:
+          throw new Error("Invalid ratio");
+      }
+
+      const result = inputLimit.mul(numerator).div(denominator);
+      inputAmount = ethers.utils.formatEther(result);
     }
   }
 

--- a/src/components/AmountInput.svelte
+++ b/src/components/AmountInput.svelte
@@ -69,7 +69,7 @@
 
   <!-- Percent buttons -->
   <div class="buttons">
-    {#each percentOptions as { value, label }, i}
+    {#each percentOptions as { value, label }, _}
       <button
         class="percent-button"
         type="button"

--- a/src/components/Polling.svelte
+++ b/src/components/Polling.svelte
@@ -56,7 +56,7 @@
 
     get(CollateralContract)!.on(
       "Transfer",
-      (src: string, dst: string, wad: BigNumber, event: Event) => {
+      (src: string, dst: string, _wad: BigNumber, _event: Event) => {
         if (src === $signerAddress || dst === $signerAddress) {
           console.log("detected WETH Transfer event");
           fetchAllDisplayData();

--- a/src/components/SelectCollateral.svelte
+++ b/src/components/SelectCollateral.svelte
@@ -15,7 +15,7 @@
   } from "src/store/contract/reads";
   import { listOfCollaterals, selectedCollateral } from "src/store/userInput";
 
-  async function handleCollateralChange(event) {
+  async function handleCollateralChange(event: any) {
     const option: string = event.target.value;
     selectedCollateral.set(option);
     setCollateralDecimals();

--- a/src/store/userInput.ts
+++ b/src/store/userInput.ts
@@ -1,4 +1,3 @@
-// TODO: get rid of number inputs since floats cause so many issues, use strings for input instead
 import { writable, derived } from "svelte/store";
 
 import { ethers } from "ethers";
@@ -18,75 +17,51 @@ export const listOfCollaterals = derived(chainId, ($chainId) => {
 });
 
 // user inputs
-export const CollateralDepositInputAmount = writable(0);
+export const CollateralDepositInputAmount = writable("0");
 
 export const CollateralDepositInputAmountBigNum = derived(
   [CollateralDepositInputAmount, collateralDecimals],
-  ([$CollateralDepositInputAmount, $collateralDecimals]) => {
+  ([$CollateralDepositInputAmount]) => {
     CollateralDepositInputError.set("");
-    if (!Number.isFinite($CollateralDepositInputAmount)) {
-      CollateralDepositInputError.set("Invalid amount!");
-    } else if ($CollateralDepositInputAmount) {
-      try {
-        return ethers.utils.parseUnits(
-          $CollateralDepositInputAmount.toString(),
-          $collateralDecimals,
-        );
-      } catch (e) {
-        CollateralDepositInputError.set("Invalid amount!");
-      }
-    } else if ($CollateralDepositInputAmount === 0) {
-      return ethers.BigNumber.from("0");
-    } else {
+    try {
+      return ethers.BigNumber.from(
+        ethers.utils.parseEther($CollateralDepositInputAmount),
+      );
+    } catch (error) {
       CollateralDepositInputError.set("Invalid amount!");
     }
   },
 );
 export const CollateralDepositInputError = writable("");
 
-export const WETHWithdrawInputAmount = writable(0);
+export const WETHWithdrawInputAmount = writable("0");
 
 export const WETHWithdrawInputAmountBigNum = derived(
   [WETHWithdrawInputAmount, collateralDecimals],
-  ([$WETHWithdrawInputAmount, $collateralDecimals]) => {
+  ([$WETHWithdrawInputAmount]) => {
     WETHWithdrawInputError.set("");
-    if (!Number.isFinite($WETHWithdrawInputAmount)) {
-      WETHWithdrawInputError.set("Invalid amount!");
-    } else if ($WETHWithdrawInputAmount) {
-      try {
-        return ethers.utils.parseUnits(
-          $WETHWithdrawInputAmount.toString(),
-          $collateralDecimals,
-        );
-      } catch (e) {
-        WETHWithdrawInputError.set("Invalid amount!");
-      }
-    } else if ($WETHWithdrawInputAmount === 0) {
-      return ethers.BigNumber.from("0");
-    } else {
-      WETHWithdrawInputError.set("Invalid amount!");
+    try {
+      return ethers.BigNumber.from(
+        ethers.utils.parseEther($WETHWithdrawInputAmount),
+      );
+    } catch (error) {
+      XOCRedeemInputError.set("Invalid amount!");
     }
   },
 );
 export const WETHWithdrawInputError = writable("");
 
-export const XOCMintInputAmount = writable(0);
+export const XOCMintInputAmount = writable("0");
 
 export const XOCMintInputAmountBigNum = derived(
   XOCMintInputAmount,
   ($XOCMintInputAmount) => {
     XOCMintInputError.set("");
-    if (!Number.isFinite($XOCMintInputAmount)) {
-      XOCMintInputError.set("Invalid amount!");
-    } else if ($XOCMintInputAmount) {
-      try {
-        return ethers.utils.parseEther($XOCMintInputAmount.toString());
-      } catch (e) {
-        XOCMintInputError.set("Invalid amount!");
-      }
-    } else if ($XOCMintInputAmount === 0) {
-      return ethers.BigNumber.from("0");
-    } else {
+    try {
+      return ethers.BigNumber.from(
+        ethers.utils.parseEther($XOCMintInputAmount),
+      );
+    } catch (error) {
       XOCMintInputError.set("Invalid amount!");
     }
   },
@@ -94,23 +69,17 @@ export const XOCMintInputAmountBigNum = derived(
 
 export const XOCMintInputError = writable("");
 
-export const XOCRedeemInputAmount = writable(0);
+export const XOCRedeemInputAmount = writable("0");
 
 export const XOCRedeemInputAmountBigNum = derived(
   XOCRedeemInputAmount,
   ($XOCRedeemInputAmount) => {
     XOCRedeemInputError.set("");
-    if (!Number.isFinite($XOCRedeemInputAmount)) {
-      XOCRedeemInputError.set("Invalid amount!");
-    } else if ($XOCRedeemInputAmount) {
-      try {
-        return ethers.utils.parseEther($XOCRedeemInputAmount.toString());
-      } catch (e) {
-        XOCRedeemInputError.set("Invalid amount!");
-      }
-    } else if ($XOCRedeemInputAmount === 0) {
-      return ethers.BigNumber.from("0");
-    } else {
+    try {
+      return ethers.BigNumber.from(
+        ethers.utils.parseEther($XOCRedeemInputAmount),
+      );
+    } catch (error) {
       XOCRedeemInputError.set("Invalid amount!");
     }
   },

--- a/src/store/userInput.ts
+++ b/src/store/userInput.ts
@@ -45,7 +45,7 @@ export const WETHWithdrawInputAmountBigNum = derived(
         ethers.utils.parseEther($WETHWithdrawInputAmount),
       );
     } catch (error) {
-      XOCRedeemInputError.set("Invalid amount!");
+      WETHWithdrawInputError.set("Invalid amount!");
     }
   },
 );


### PR DESCRIPTION
Closes [#56](https://github.com/La-DAO/xocolatl-frontend/issues/56)

Modified userInputs to allow Deposit, Mint and Withdraw to allow strings and to return BigNumber.

`src/components/AmountInput.svelte` variable `inputAmount` is now string. 