### PR TITLE
fix: manual input in dashboard fields

### DIFF
--- a/src/components/AmountInput.svelte
+++ b/src/components/AmountInput.svelte
@@ -61,7 +61,7 @@
 <div class="deposit-amount-section">
   <h1 class="deposit-header">{headerText}</h1>
   <label for="amount"></label>
-  <input id="amount" bind:value={inputAmount} type="number" min="0" lang="en" />
+  <input id="amount" bind:value={inputAmount} type="text" lang="en" />
 
   <div class="collateral-type">
     {inputTypeText}: <SelectCollateral />
@@ -137,7 +137,7 @@
     -webkit-appearance: none;
     margin: 0;
   }
-  input[type="number"] {
+  input[type="text"] {
     -moz-appearance: textfield;
   }
 </style>


### PR DESCRIPTION
The changes in PR #57 broke the manual inputs for `Deposit` `Mint` `Withdraw` and `Payback`.
This PR restore proper functionality after change to "string" type for input.